### PR TITLE
Dockerfile: Update composer to 2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM php:7.4.6-alpine
 RUN apk add --no-cache tini
 
 # Install PHP Code Standard Fixer - https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases
-COPY --from=composer:1.10.6 /usr/bin/composer /usr/bin/composer
+COPY --from=composer:2.0.0 /usr/bin/composer /usr/bin/composer
 RUN COMPOSER_HOME="/composer" \
 	composer global require --prefer-dist --no-progress --no-suggest --dev friendsofphp/php-cs-fixer:2.16.3
 ENV PATH /composer/vendor/bin:${PATH}


### PR DESCRIPTION

Image **composer** updated from 1.10.6 to 2.0

**Image:** [composer](https://hub.docker.com/r/library/composer/)  
**Version:** 1.10.6 &rarr; 2.0  
**Dockerfile:** Dockerfile  


If you need help or something went wrong, please comment here while mentioning me (@DockerUpBot) or use the [support formular](https://dockerup.net/support?repo=d3db557a-ea3b-4cb3-8fb3-a6f18d9b9fff).

<hr>
<p align="center">
  <a href="https://dockerup.net"><img align="center" src="https://dockerup.net/img/logo.svg" alt="Docker Up" width="200px"></a>
<br>
Automated <b>Dockerfile</b> updates
</p>
	